### PR TITLE
Refactor/transcriber fastapi

### DIFF
--- a/transcriber/.gitignore
+++ b/transcriber/.gitignore
@@ -1,1 +1,3 @@
 .venv
+transcripts
+videos

--- a/transcriber/transcripts/README.md
+++ b/transcriber/transcripts/README.md
@@ -1,0 +1,1 @@
+main.py adds transcripts to this dir


### PR DESCRIPTION
This pull request refactors the `transcriber` project to convert it into a FastAPI-based web application for video transcription. Key changes include introducing an HTTP endpoint for uploading and transcribing video files, updating the `.gitignore` file, and adding documentation for the `transcripts` directory.

### FastAPI Integration:
* [`transcriber/main.py`](diffhunk://#diff-410127db9a16363df80f7200937afdfaf12231538815660923507e8dc151293fL1-R33): Replaced the standalone script with a FastAPI server. Added an endpoint `/transcribe/` to handle video file uploads, validate file types, perform transcription using Whisper, and return the transcript as a downloadable file.

### Project Structure Updates:
* [`transcriber/.gitignore`](diffhunk://#diff-77a688d59a2ba0779af8913f5dcbe58a6c60f12a8b86d64a66dbbceda399531bR2-R3): Added `transcripts` and `videos` directories to the `.gitignore` file to exclude generated files from version control.

### Documentation:
* [`transcriber/transcripts/README.md`](diffhunk://#diff-ed1ab79c7f9887e8ca40f09f95e3b2b6fc73deb7d9d2cf604ed486f649adda7aR1): Added a note indicating that `main.py` stores transcripts in the `transcripts` directory.